### PR TITLE
Add Microsoft Developer Changelog RSS feed

### DIFF
--- a/config/rss-feeds.json
+++ b/config/rss-feeds.json
@@ -1,6 +1,11 @@
 {
   "feeds": [
     {
+      "name": "Microsoft Developer Changelog",
+      "url": "https://developer.microsoft.com/api/changelog/rss",
+      "website_url": "https://developer.microsoft.com/en-us/changelog"
+    },
+    {
       "name": "Microsoft DevOps Blog",
       "url": "https://devblogs.microsoft.com/devops/feed/",
       "website_url": "https://devblogs.microsoft.com/devops/"


### PR DESCRIPTION
This pull request adds a new RSS feed to the configuration by including the Microsoft Developer Changelog. No other changes were made.

- Added the Microsoft Developer Changelog to the `feeds` list in `config/rss-feeds.json`, including its name, RSS URL, and website URL.